### PR TITLE
Updated Twitter SDK [ New Version-1.2.0 ]

### DIFF
--- a/src/twitter4jads/BaseAdsListResponse.java
+++ b/src/twitter4jads/BaseAdsListResponse.java
@@ -1,6 +1,7 @@
 package twitter4jads;
 
 import com.google.gson.annotations.SerializedName;
+import twitter4jads.internal.models4j.JobLimitStatus;
 import twitter4jads.internal.models4j.RateLimitStatus;
 import twitter4jads.internal.models4j.TwitterResponse;
 import twitter4jads.models.ads.RequestParameters;
@@ -35,6 +36,8 @@ public class BaseAdsListResponse<T> implements Serializable, TwitterResponse {
     private Long count;
 
     private RateLimitStatus rateLimitStatus;
+
+    private JobLimitStatus jobLimitStatus;
 
     private int accessLevel;
 
@@ -85,6 +88,14 @@ public class BaseAdsListResponse<T> implements Serializable, TwitterResponse {
 
     public void setRateLimitStatus(RateLimitStatus rateLimitStatus) {
         this.rateLimitStatus = rateLimitStatus;
+    }
+
+    public JobLimitStatus getJobLimitStatus() {
+        return jobLimitStatus;
+    }
+
+    public void setJobLimitStatus(JobLimitStatus jobLimitStatus) {
+        this.jobLimitStatus = jobLimitStatus;
     }
 
     @Override

--- a/src/twitter4jads/BaseAdsListResponseIterable.java
+++ b/src/twitter4jads/BaseAdsListResponseIterable.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import org.apache.commons.lang3.StringUtils;
 import twitter4jads.internal.http.HttpParameter;
 import twitter4jads.internal.http.HttpResponse;
+import twitter4jads.internal.models4j.JobLimitStatus;
 import twitter4jads.internal.models4j.RateLimitStatus;
 import twitter4jads.internal.models4j.TwitterException;
 import twitter4jads.models.ads.TwitterRuntimeException;
@@ -51,6 +52,10 @@ public class BaseAdsListResponseIterable<T> implements Iterable<BaseAdsListRespo
             rateLimitStatus = TwitterAdHttpUtils.createFromResponseHeader(response);
         }
         data.setRateLimitStatus(rateLimitStatus);
+
+        JobLimitStatus jobLimitStatus;
+        jobLimitStatus = TwitterAdHttpUtils.getJobLimitDataFromResponseHeader(response);
+        data.setJobLimitStatus(jobLimitStatus);
         if (TwitterAdUtil.isNotEmpty(data.getData()) && data.getNextCursor() != null) {
             nextCursor = data.getNextCursor();
         }

--- a/src/twitter4jads/api/TwitterAdsStatApi.java
+++ b/src/twitter4jads/api/TwitterAdsStatApi.java
@@ -91,4 +91,7 @@ public interface TwitterAdsStatApi {
     BaseAdsResponse<JobDetails> deleteJob(String accountId, String jobId) throws TwitterException;
 
     BaseAdsListResponseIterable<TwitterActiveEntity> fetchActiveEntities(String accountId, TwitterEntityType twitterEntity, Collection<String> fundingInstrumentIds, Collection<String> campaignIds, Collection<String> lineItemIds, String startTime, String endTime) throws TwitterException;
+
+    BaseAdsListResponseIterable<JobDetails> getCurrJobsMetrics(String accountId) throws TwitterException;
+
 }

--- a/src/twitter4jads/impl/TwitterAdsStatApiImpl.java
+++ b/src/twitter4jads/impl/TwitterAdsStatApiImpl.java
@@ -269,4 +269,14 @@ public class TwitterAdsStatApiImpl implements TwitterAdsStatApi {
         return twitterAdsClient.executeHttpListRequest(baseUrl, params, type);
     }
 
+    @Override
+    public BaseAdsListResponseIterable<JobDetails> getCurrJobsMetrics(String accountId) throws TwitterException {
+        TwitterAdUtil.ensureNotNull(accountId, TwitterAdsConstants.ACCOUNT_ID);
+        final String baseUrl = twitterAdsClient.getBaseAdsAPIUrl() + TwitterAdsConstants.PREFIX_STATS_JOB_ACCOUNTS_URI + accountId;
+
+        Type type = new TypeToken<BaseAdsListResponse<JobDetails>>() {
+        }.getType();
+
+        return twitterAdsClient.executeHttpListRequest(baseUrl , null,type);
+    }
 }

--- a/src/twitter4jads/internal/models4j/JobLimitStatus.java
+++ b/src/twitter4jads/internal/models4j/JobLimitStatus.java
@@ -1,0 +1,8 @@
+package twitter4jads.internal.models4j;
+
+public interface JobLimitStatus extends java.io.Serializable {
+
+    int getJobLimit();
+
+    int getJobLimitRemaining();
+}

--- a/src/twitter4jads/internal/models4j/JobLimitStatusImpl.java
+++ b/src/twitter4jads/internal/models4j/JobLimitStatusImpl.java
@@ -1,0 +1,31 @@
+package twitter4jads.internal.models4j;
+
+public class JobLimitStatusImpl implements JobLimitStatus {
+
+    private final int jobLimit;
+    private final int jobLimitRemaining;
+
+    public JobLimitStatusImpl(int jobLimit, int jobLimitRemaining) {
+        this.jobLimit = jobLimit;
+        this.jobLimitRemaining = jobLimitRemaining;
+    }
+
+    @Override
+    public int getJobLimit() {
+        return this.jobLimit;
+    }
+
+    @Override
+    public int getJobLimitRemaining() {
+        return this.jobLimitRemaining;
+    }
+
+    @Override
+    public String toString() {
+        return "JobLimitStatusImpl {" +
+                "remaining=" + this.jobLimitRemaining +
+                ", limit=" + this.jobLimit +
+                "}";
+    }
+
+}

--- a/src/twitter4jads/util/TwitterAdHttpUtils.java
+++ b/src/twitter4jads/util/TwitterAdHttpUtils.java
@@ -1,5 +1,6 @@
 package twitter4jads.util;
 
+import twitter4jads.internal.models4j.JobLimitStatusImpl;
 import twitter4jads.internal.models4j.RateLimitStatusImpl;
 import twitter4jads.internal.http.HttpResponse;
 
@@ -63,5 +64,22 @@ public class TwitterAdHttpUtils {
         }
 
         return new RateLimitStatusImpl(remainingHits, limit, resetTimeInSeconds, costValue);
+    }
+
+    public static JobLimitStatusImpl getJobLimitDataFromResponseHeader(HttpResponse res) {
+        int limit = 0;
+        int remaining = 0;
+
+        String strLimit = res.getResponseHeader("x-concurrent-job-limit");
+        if(strLimit !=null) {
+            limit = Integer.parseInt(strLimit);
+        }
+
+        String strRemaining = res.getResponseHeader("x-concurrent-job-limit-remaining");
+        if(strRemaining != null) {
+            remaining = Integer.parseInt(strRemaining);
+        }
+
+        return new JobLimitStatusImpl(limit,remaining);
     }
 }

--- a/src/twitter4jads/util/TwitterAdHttpUtils.java
+++ b/src/twitter4jads/util/TwitterAdHttpUtils.java
@@ -70,12 +70,12 @@ public class TwitterAdHttpUtils {
         int limit = 0;
         int remaining = 0;
 
-        String strLimit = res.getResponseHeader("x-concurrent-job-limit");
+        String strLimit = res.getResponseHeader("X-Concurrent-Job-Limit");
         if(strLimit !=null) {
             limit = Integer.parseInt(strLimit);
         }
 
-        String strRemaining = res.getResponseHeader("x-concurrent-job-limit-remaining");
+        String strRemaining = res.getResponseHeader("X-Concurrent-Job-Limit-Remaining");
         if(strRemaining != null) {
             remaining = Integer.parseInt(strRemaining);
         }


### PR DESCRIPTION
Added functionality in SDK to get Job Metrics of particular account which will give us information whether we can schedule a new job on Twitter-Ads account or not and eventually avoid TwitterException as Twitter keeps changing the limit on No. of jobs that can in processing state and to make our code tolerate such changes and not fail this Job Metrics is needed.


Jira Ticket --> [INT-735](https://hevodata.atlassian.net/browse/INT-735)

Doc Link --> https://developer.twitter.com/en/docs/twitter-ads-api/analytics/api-reference/asynchronous